### PR TITLE
Set destructive mode as false

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,8 +18,9 @@ jobs:
 
   release:
     needs: check
-    uses: canonical/bootstack-actions/.github/workflows/charm-release.yaml@v2
+    uses: canonical/bootstack-actions/.github/workflows/charm-release.yaml@v3
     secrets: inherit
     with:
       channel: "latest/edge"
       upload-image: false
+      destructive-mode: false


### PR DESCRIPTION
This is needed because we need to build this charm on 20.04 as well, even though the release job runs on ubuntu/latest