### PR TITLE
add jammy and x64 labels for self hosted

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
     with:
       command: "make functional"
-      runs-on: "['self-hosted', 'xlarge']"
+      runs-on: "['self-hosted', 'xlarge', 'jammy', 'x64']"
       juju-channel: "3.1/stable"
       nested-containers: false
       provider: "lxd"


### PR DESCRIPTION
This is so that the workflow keeps working as we add more architectures and Ubuntu OS versions