### PR TITLE
Remove Jinja2 due to security alert, add runs-on for self-hosted runner

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
     with:
       command: "TEST_JUJU3=1 make functional"  # using TEST_JUJU3 due https://github.com/openstack-charmers/zaza/commit/af7eea953dd5d74d3d074fe67b5765dca3911ca6
-      runs-on: "['self-hosted', 'xlarge', 'jammy', 'x64']"
+      runs-on: "['self-hosted', 'linux', 'x64', 'large', 'jammy']"
       juju-channel: "3.4/stable"
       nested-containers: false
       provider: "lxd"

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -25,7 +25,7 @@ jobs:
       python-version: ${{ matrix.python-version }}
 
   func:
-    uses: canonical/bootstack-actions/.github/workflows/func.yaml@v3
+    uses: canonical/bootstack-actions/.github/workflows/func.yaml@v2
     needs: lint-unit
     strategy:
       fail-fast: false

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -25,12 +25,13 @@ jobs:
       python-version: ${{ matrix.python-version }}
 
   func:
-    uses: canonical/bootstack-actions/.github/workflows/func.yaml@v2
+    uses: canonical/bootstack-actions/.github/workflows/func.yaml@v3
     needs: lint-unit
     strategy:
       fail-fast: false
     with:
       command: "TEST_JUJU3=1 make functional"  # using TEST_JUJU3 due https://github.com/openstack-charmers/zaza/commit/af7eea953dd5d74d3d074fe67b5765dca3911ca6
+      runs-on: "['self-hosted', 'xlarge', 'jammy', 'x64']"
       juju-channel: "3.4/stable"
       nested-containers: false
       provider: "lxd"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 git+https://git.launchpad.net/juju-backup-all@23.10#egg=juju-backup-all
 charmhelpers >= 0.20.23
-markupsafe
-jinja2
 ops >= 1.2.0
 typing-extensions <4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+https://git.launchpad.net/juju-backup-all@23.10#egg=juju-backup-all
 charmhelpers >= 0.20.23
-jinja2 < 3
+jinja2
 ops >= 1.2.0
 typing-extensions <4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 git+https://git.launchpad.net/juju-backup-all@23.10#egg=juju-backup-all
 charmhelpers >= 0.20.23
-jinja2 >= 3.1.3
+markupsafe
+jinja2
 ops >= 1.2.0
 typing-extensions <4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+https://git.launchpad.net/juju-backup-all@23.10#egg=juju-backup-all
 charmhelpers >= 0.20.23
-jinja2 >= 3.1.3
+jinja2 < 3
 ops >= 1.2.0
 typing-extensions <4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+https://git.launchpad.net/juju-backup-all@23.10#egg=juju-backup-all
 charmhelpers >= 0.20.23
-jinja2 < 3
+jinja2 >= 3.1.3
 ops >= 1.2.0
 typing-extensions <4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+https://git.launchpad.net/juju-backup-all@23.10#egg=juju-backup-all
 charmhelpers >= 0.20.23
-jinja2
+jinja2 >= 3.1.3
 ops >= 1.2.0
 typing-extensions <4.2


### PR DESCRIPTION
There was a security alert about a vulnerable version of jinja. After investigation I found jinja2 is not used hence I removed it.
Specifying runs-on for self hosted runner, otherwise arm will picked up by default. Using xlarge to avoid disk ran out.