### PR TITLE
Add config options to choose backup location for the DB charms.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -92,3 +92,14 @@ options:
     type: int
     default: 10000
     description: Start the exporter at "exporter-port".
+  backup-basedir:
+    type: string
+    default: "/opt/backups"
+    description: |
+      The directory to be used by the charms (not charm-juju-backup-all) to
+      save the backups. The "backup-basedir" will be created if it does not
+      exist. This config option is useful to workaround the issue that the disk
+      on the charm is full, or the default backup path is not writable.
+
+      Please do not be confused with "backup-dir" option which specify the
+      output directory of the backups for charm-juju-backup-all.

--- a/config.yaml
+++ b/config.yaml
@@ -92,14 +92,36 @@ options:
     type: int
     default: 10000
     description: Start the exporter at "exporter-port".
-  backup-basedir:
+  backup-location-on-postgresql:
     type: string
-    default: "/opt/backups"
+    default: "/home/ubuntu"
     description: |
-      The directory to be used by the charms (not charm-juju-backup-all) to
-      save the backups. The "backup-basedir" will be created if it does not
-      exist. This config option is useful to workaround the issue that the disk
-      on the charm is full, or the default backup path is not writable.
+      The directory to be used by the postgresql charm to save the backups. The
+      "backup-location-on-postgresql" will be created if it does not exist.
+      This config option is useful to workaround the issue that the disk on the
+      charm is full, or the default backup path is not writable.
+
+      Please do not be confused with "backup-dir" option which specify the
+      output directory of the backups for charm-juju-backup-all.
+  backup-location-on-mysql:
+    type: string
+    default: "/var/backups/mysql"
+    description: |
+      The directory to be used by the postgresql charm to save the backups. The
+      "backup-location-on-mysql" will be created if it does not exist.
+      This config option is useful to workaround the issue that the disk on the
+      charm is full, or the default backup path is not writable.
+
+      Please do not be confused with "backup-dir" option which specify the
+      output directory of the backups for charm-juju-backup-all.
+  backup-location-on-etcd:
+    type: string
+    default: "/home/ubuntu/etcd-snapshots"
+    description: |
+      The directory to be used by the postgresql charm to save the backups. The
+      "backup-location-on-etcd" will be created if it does not exist.
+      This config option is useful to workaround the issue that the disk on the
+      charm is full, or the default backup path is not writable.
 
       Please do not be confused with "backup-dir" option which specify the
       output directory of the backups for charm-juju-backup-all.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://git.launchpad.net/juju-backup-all@23.10#egg=juju-backup-all
+git+https://github.com/canonical/juju-backup-all.git@1.1.0
 charmhelpers >= 0.20.23
 ops >= 1.2.0
 typing-extensions <4.2

--- a/src/utils.py
+++ b/src/utils.py
@@ -248,6 +248,7 @@ class JujuBackupAllHelper:
             "log_level": "INFO",
             "output_dir": self.charm_config["backup-dir"],
             "timeout": self.charm_config["timeout"],
+            "app_backup_basedir": self.charm_config["backup-basedir"],
         }
 
     def _update_dir_owner(self, path):

--- a/src/utils.py
+++ b/src/utils.py
@@ -248,7 +248,11 @@ class JujuBackupAllHelper:
             "log_level": "INFO",
             "output_dir": self.charm_config["backup-dir"],
             "timeout": self.charm_config["timeout"],
-            "app_backup_basedir": self.charm_config["backup-basedir"],
+            "backup_location_on_postgresql": self.charm_config[
+                "backup-location-on-postgresql"
+            ],
+            "backup_location_on_mysql": self.charm_config["backup-location-on-mysql"],
+            "backup_location_on_etcd": self.charm_config["backup-location-on-etcd"],
         }
 
     def _update_dir_owner(self, path):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -38,7 +38,9 @@ MOCK_CONFIG = {
     "crontab": "10 20 * *",
     "backup-retention-period": 7,
     "exclude-models": "",
-    "backup-basedir": "/home/ubuntu",
+    "backup-location-on-postgresql": "/home/ubuntu",
+    "backup-location-on-mysql": "/var/backups/mysql",
+    "backup-location-on-etcd": "/home/ubuntu/etcd-snapshots",
 }
 
 SSH_FINGERPRINT = "a3:fe:56:ca:d8:e8:ea:04:f2:9a:fd:0f:bf:55:7c:17 (jujubackup@juju-deb4b2-tmp-7)"  # noqa E501

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -38,6 +38,7 @@ MOCK_CONFIG = {
     "crontab": "10 20 * *",
     "backup-retention-period": 7,
     "exclude-models": "",
+    "backup-basedir": "/home/ubuntu",
 }
 
 SSH_FINGERPRINT = "a3:fe:56:ca:d8:e8:ea:04:f2:9a:fd:0f:bf:55:7c:17 (jujubackup@juju-deb4b2-tmp-7)"  # noqa E501


### PR DESCRIPTION
Add config options for choose backup location for the DB charms

This provide a potential workaround if the disk of the application machine is full, or the default backup directory is not writable.

depends: https://github.com/canonical/juju-backup-all/issues/49