### PR TITLE
fix: use j-b-a python package 1.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://git.launchpad.net/juju-backup-all@23.10#egg=juju-backup-all
+git+https://github.com/canonical/juju-backup-all.git@1.1.0
 charmhelpers >= 0.20.23
 ops >= 1.2.0
 typing-extensions <4.2


### PR DESCRIPTION
Update the old link to j-b-a package and use the latest version (as of this PR, `latest==1.1.0`) of that package