### PR TITLE
Fix charm build failure

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -25,15 +25,40 @@ jobs:
       python-version: ${{ matrix.python-version }}
 
   func:
-    uses: canonical/bootstack-actions/.github/workflows/func.yaml@v3
     needs: lint-unit
+    name: functional tests
+    runs-on: ${{ matrix.architecture.runs-on }}
+    timeout-minutes: 120
     strategy:
       fail-fast: false
-    with:
-      command: "TEST_JUJU3=1 make functional"  # using TEST_JUJU3 due https://github.com/openstack-charmers/zaza/commit/af7eea953dd5d74d3d074fe67b5765dca3911ca6
-      runs-on: "['self-hosted', 'linux', 'x64', 'large', 'jammy']"
-      juju-channel: "3.4/stable"
-      nested-containers: false
-      provider: "lxd"
-      python-version: "3.10"
-      timeout-minutes: 120
+      matrix:
+        juju-channel: ["3.4/stable"]
+        architecture:
+          - runs-on: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Setup Juju environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: "lxd"
+          juju-channel: ${{ matrix.juju-channel }}
+          charmcraft-channel: "2.x/stable"
+      - name: Install latest tox version
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
+      - name: Show juju information
+        run: |
+          juju version
+          juju controllers | grep Version -A 1 | awk '{print $9}'
+      - name: Run tests
+        run: "make functional"
+        env:
+          TEST_JUJU3: "1"  # https://github.com/openstack-charmers/zaza/pull/653
+          TEST_MODEL_CONSTRAINTS: ${{ matrix.architecture.model-constraints }}

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         juju-channel: ["3.4/stable"]
         architecture:
-          - runs-on: [ubuntu-latest]
+          - runs-on: [self-hosted, linux, x64, large, jammy]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,5 +25,6 @@ jobs:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "latest/edge"
+          charmcraft-channel: "2.x/stable"
           # Note(rgildein): Right now we are not using destructive-mode, since our charmcraft.yaml is designed with a single build-on and the ability to run-on multiple bases. Running with destructive-mode would require aligning the base defined in this job with the one defined in charmcraft.yaml (build-on).
           destructive-mode: false

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -7,13 +7,12 @@ parts:
   charm:
     plugin: charm
     source: .
+    charm-binary-python-packages:
+      # use a binary distribution rather than build from public source code,
+      # and it reduces a bunch of unnecessary build dependencies
+      - juju
     build-packages:
-      - cargo
       - git
-      - libffi-dev
-      - libssl-dev
-      - pkg-config
-      - rustc
   scripts:
     plugin: dump
     source: .

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -5,6 +5,8 @@ type: "charm"
 # in focal doesn't work in jammy and vice versa.
 parts:
   charm:
+    plugin: charm
+    source: .
     build-packages:
       - cargo
       - git
@@ -12,7 +14,11 @@ parts:
       - libssl-dev
       - pkg-config
       - rustc
-    prime: ["scripts"]
+  scripts:
+    plugin: dump
+    source: .
+    prime:
+      - scripts
 bases:
   - build-on:
     - name: ubuntu

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -5,8 +5,13 @@ type: "charm"
 # in focal doesn't work in jammy and vice versa.
 parts:
   charm:
-    build-packages: [git]
-    charm-python-packages: [setuptools < 58]
+    build-packages:
+      - cargo
+      - git
+      - libffi-dev
+      - libssl-dev
+      - pkg-config
+      - rustc
     prime: ["scripts"]
 bases:
   - build-on:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -13,9 +13,6 @@ parts:
       - juju
     build-packages:
       - git
-  scripts:
-    plugin: dump
-    source: .
     prime:
       - scripts
 bases:


### PR DESCRIPTION
Fix charm build failure:

```shell
::    ::             x86_64-linux-gnu-gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -fPIC -DFFI_BUILDING=1 -DUSE__THREAD -DHAVE_SYNC_SYNCHRONIZE -I/usr/include/ffi -I/usr/include/libffi -I/root/parts/charm/build/staging-venv/include -I/usr/include/python3.10 -c src/c/_cffi_backend.c -o build/temp.linux-x86_64-cpython-310/src/c/_cffi_backend.o
::    ::             src/c/_cffi_backend.c:15:10: fatal error: ffi.h: No such file or directory
::    ::                15 | #include <ffi.h>
::    ::                   |          ^~~~~~~
::    ::             compilation terminated.
::    ::             error: command '/usr/bin/x86_64-linux-gnu-gcc' failed with exit code 1
::    ::             [end of output]
::    ::
::    ::         note: This error originates from a subprocess, and is likely not a problem with pip.
::    ::         ERROR: Failed building wheel for cffi
::    ::       Failed to build cffi
::    ::       ERROR: ERROR: Failed to build installable wheels for some pyproject.toml based projects (cffi)
::    ::       [end of output]
```

https://github.com/canonical/charm-juju-backup-all/actions/runs/10190245205/job/28189653691