### PR TITLE
Bump charming-action to latest release as of now (2.6.2)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Initialize lxd  # This should dropped once it's implemented on charming-actions itself. https://github.com/canonical/charming-actions/issues/140
         uses: canonical/setup-lxd@v0.1.1
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.4.0
+        uses: canonical/charming-actions/upload-charm@2.6.2
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Bump charming-action to latest release as of now (2.6.2).

upload-charm action support release multiple charm files since revision 2.5.0-rc