### PR TITLE
Fix import order for auto_backup script

### DIFF
--- a/scripts/templates/auto_backup.py
+++ b/scripts/templates/auto_backup.py
@@ -33,9 +33,9 @@ import yaml
 
 # The path below is templated in during charm install this is required to load
 # the charm code and dependencies from this script.
-sys.path.append("REPLACE_CHARMDIR/lib")
-sys.path.append("REPLACE_CHARMDIR/src")
-sys.path.append("REPLACE_CHARMDIR/venv")
+sys.path.insert(0, "REPLACE_CHARMDIR/venv")
+sys.path.insert(0, "REPLACE_CHARMDIR/src")
+sys.path.insert(0, "REPLACE_CHARMDIR/lib")
 
 from jujubackupall import globals  # noqa E402
 from jujubackupall.config import Config  # noqa E402


### PR DESCRIPTION
Charm-specific paths should be prepended to sys.path to ensure that these directories are searched first. If they are not searched first,
then it's possible that system installed packages
may be favoured over those shipped with the charm, potentially resulting in incorrect package versions being imported.

Possibly related to #35
(see the traceback including system packages)