### PR TITLE
Using tmp branch of j-b-a for support 2.9

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -84,7 +84,7 @@ jobs:
       matrix:
         runs-on: [[self-hosted, linux, x64, large, jammy]]
         test-command: ['tox -e func']
-        juju-channel: ["3.4/stable"]
+        juju-channel: ["2.9/stable"]
     steps:
 
       - uses: actions/checkout@v4
@@ -133,7 +133,6 @@ jobs:
           echo "$CHARM_PATH_FOCAL"
           ${{ matrix.test-command }}
         env:
-          TEST_JUJU3: "1"  # https://github.com/openstack-charmers/zaza/pull/653
           TEST_JUJU_CHANNEL: ${{ matrix.juju-channel }}
 
       # Save output for debugging

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/canonical/juju-backup-all.git@1.1.0
+git+https://github.com/canonical/juju-backup-all.git@tmp/juju-2.9
 charmhelpers >= 0.20.23
 ops >= 1.2.0
 typing-extensions <4.2

--- a/tests/functional/tests/test_backups.py
+++ b/tests/functional/tests/test_backups.py
@@ -48,7 +48,7 @@ class JujuBackupAllTests(unittest.TestCase):
     def test_02_do_backup_action(self):
         """Test: do-backup action performed successfully."""
         action = model.run_action_on_leader(self.app_name, "do-backup")
-        assert action.data["results"].get("return-code") == 0, "Backup action failed."
+        assert action.data["results"].get("Code") == "0", "Backup action failed."
 
         result_str = action.data["results"].get("result")
         assert result_str is not None, "Action returned None!"


### PR DESCRIPTION
We need to tmp support Juju 2.9, and charm need to use j-b-a python package with libjuju 2.9.

fixes: #53