### PR TITLE
Switch to latest/edge for etcd in func tests

### DIFF
--- a/tests/functional/tests/bundles/base.yaml
+++ b/tests/functional/tests/bundles/base.yaml
@@ -13,6 +13,8 @@ applications:
     num_units: 3
   etcd:
     charm: etcd
+    # NOTE: switch back to stable when the fix for https://bugs.launchpad.net/charm-etcd/+bug/2096820 is released to stable
+    channel: latest/edge
     num_units: 1
   easyrsa:
     charm: easyrsa


### PR DESCRIPTION
This should fix the func tests.

So we get the fix for https://bugs.launchpad.net/charm-etcd/+bug/2096820 (it's not released to stable yet).

Currently the tests are failing because zaza expects etcd to be "Healthy with 1 known peer", but due to the above bug, the etcd charm on stable erroneously reports 2 known peers.