### PR TITLE
Fix partial errors being missed in nagios (#59)

### DIFF
--- a/scripts/templates/auto_backup.py
+++ b/scripts/templates/auto_backup.py
@@ -72,10 +72,26 @@ def check_backup_file(backup_results_file):
     try:
         with open(backup_results_file, "r") as f:
             backup_results = json.load(f)
+            # "ERROR" will contain a traceback if something crashed during the backups.
+            # See AutoJujuBackupAll.run()
             if "ERROR" in backup_results:
                 logger.error(
                     "Detected error when performing backup: '%s'",
                     backup_results["ERROR"],
+                )
+                return 2
+
+            # This entry is populated by the jujubackupall backup process
+            # (see `BackupTracker.add_error` in jujubackupall),
+            # and indicates which backups failed.
+            # Some backups may have succeeded, but any backup failure
+            # should be considered a critical error,
+            # because silent failed backups
+            # can result in inability to recover from data loss events.
+            if "errors" in backup_results:
+                logger.error(
+                    "Detected error when performing backup: '%s'",
+                    backup_results["errors"],
                 )
                 return 2
 

--- a/tests/functional/tests/tests.yaml
+++ b/tests/functional/tests/tests.yaml
@@ -22,7 +22,7 @@ target_deploy_status:
     workload-status-message-prefix: "Primary"
   etcd:
     workload-status: "active"
-    workload-status-message-prefix: "Healthy with 1 known peer"
+    workload-status-message-prefix: "Healthy with"
   easyrsa:
     workload-status: "active"
     workload-status-message-prefix: "Certificate Authority connected."


### PR DESCRIPTION
Errors from exceptions in the backup process were being reported, but no errors were reported if some apps or juju controllers failed in the backup process (while others may have succeeded).

Fixes: #55


---

Cherry pick #59 
It's a back port for 2.9 support.