### PR TITLE
Pin tenacity for python <= 3.8

### DIFF
--- a/tests/functional/requirements.txt
+++ b/tests/functional/requirements.txt
@@ -1,2 +1,3 @@
 git+https://github.com/openstack-charmers/zaza.git@master#egg=zaza
 python-openstackclient
+tenacity < 9.1.1; python_version <= "3.8"  # See https://github.com/jd/tenacity/releases/tag/9.1.1


### PR DESCRIPTION
tenacity drop python 3.8 support since 9.1.1. See https://github.com/jd/tenacity/releases/tag/9.1.1