### PR TITLE
Pin etcd charm to Jammy for Functional test

### DIFF
--- a/tests/functional/tests/bundles/base.yaml
+++ b/tests/functional/tests/bundles/base.yaml
@@ -15,6 +15,8 @@ applications:
     charm: etcd
     # NOTE: switch back to stable when the fix for https://bugs.launchpad.net/charm-etcd/+bug/2096820 is released to stable
     channel: latest/edge
+    # Etcd drops support for Focal
+    series: jammy
     num_units: 1
   easyrsa:
     charm: easyrsa

--- a/tests/functional/tests/bundles/base.yaml
+++ b/tests/functional/tests/bundles/base.yaml
@@ -13,8 +13,7 @@ applications:
     num_units: 3
   etcd:
     charm: etcd
-    # NOTE: switch back to stable when the fix for https://bugs.launchpad.net/charm-etcd/+bug/2096820 is released to stable
-    channel: latest/edge
+    channel: latest/stable
     # Etcd drops support for Focal
     series: jammy
     num_units: 1


### PR DESCRIPTION
Functional test failed saying `tenacity` package required Python >= 3.9. See [line 327](https://github.com/canonical/charm-juju-backup-all/actions/runs/15244377662/job/42881094465?pr=85#:~:text=327-,Error%3A%20%2D26%2007%3A54%3A55%20%5BERROR%5D%20unit%2Detcd%2D0.log,328,-Error%3A%20%2D26). It is a dependency from charm `etcd` and looks like `etcd` charm from latest/edge is defaulting to Focal (Python 3.8), so pin it to Jammy ( with Python 3.10) may help here.