### PR TITLE
chore: use juju-backup-all 1.2.1  

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/canonical/juju-backup-all.git@1.2.0
+git+https://github.com/canonical/juju-backup-all.git@1.2.1
 charmhelpers
 ops
 typing-extensions

--- a/scripts/templates/auto_backup.py
+++ b/scripts/templates/auto_backup.py
@@ -37,9 +37,6 @@ sys.path.insert(0, "REPLACE_CHARMDIR/venv")
 sys.path.insert(0, "REPLACE_CHARMDIR/src")
 sys.path.insert(0, "REPLACE_CHARMDIR/lib")
 
-from jujubackupall import (  # noqa E402, pylint: disable=redefined-builtin,wrong-import-position
-    globals,
-)
 from jujubackupall.config import Config  # noqa E402, pylint: disable=wrong-import-position
 from jujubackupall.process import (  # noqa E402, pylint: disable=wrong-import-position
     BackupProcessor,
@@ -231,9 +228,6 @@ class AutoJujuBackupAll:
 
         log_level = logging.DEBUG if args.debug else logging.ERROR
         self.configure_logging(log_level=log_level)
-
-        if args.task_timeout > 0:
-            globals.async_timeout = args.task_timeout
 
         # Ensure a single instance via a simple pidfile
         pid = str(os.getpid())

--- a/src/utils.py
+++ b/src/utils.py
@@ -15,6 +15,7 @@ import yaml
 from charmhelpers.contrib.charmsupport.nrpe import NRPE
 from charmhelpers.core import hookenv, host
 from charmhelpers.core.host import rsync
+from jujubackupall import globals
 from jujubackupall.config import Config
 from jujubackupall.process import BackupProcessor
 from jujubackupall.utils import connect_controller, connect_model
@@ -143,6 +144,8 @@ class JujuBackupAllHelper:
         """Perform backups."""
         # first ensure the ssh key is in all models, then perform the backup
         self.push_ssh_keys()
+        # ensure the global variables are updated in the jujubackupall globals
+        self.update_global_vars()
         backup_processor = BackupProcessor(self.config)
         backup_results = backup_processor.process_backups(omit_models=omit_models)
         logging.info("backup results = '%s'", backup_results)
@@ -154,6 +157,11 @@ class JujuBackupAllHelper:
         ssh_helper = SSHKeyHelper(self.config, self.accounts)
         ssh_helper.push_ssh_keys_to_models()
         return "success"
+
+    def update_global_vars(self):
+        """Update global variables used by the Juju-backup-all library."""
+        if self.charm_config["timeout"]:
+            globals.async_timeout = self.charm_config["timeout"]
 
     def update_crontab(self):
         """Update crontab "/etc/cron.d/juju-backup-all" that runs "auto_backup.py"."""

--- a/src/utils.py
+++ b/src/utils.py
@@ -15,7 +15,6 @@ import yaml
 from charmhelpers.contrib.charmsupport.nrpe import NRPE
 from charmhelpers.core import hookenv, host
 from charmhelpers.core.host import rsync
-from jujubackupall import globals
 from jujubackupall.config import Config
 from jujubackupall.process import BackupProcessor
 from jujubackupall.utils import connect_controller, connect_model
@@ -144,8 +143,6 @@ class JujuBackupAllHelper:
         """Perform backups."""
         # first ensure the ssh key is in all models, then perform the backup
         self.push_ssh_keys()
-        # ensure the global variables are updated in the jujubackupall globals
-        self.update_global_vars()
         backup_processor = BackupProcessor(self.config)
         backup_results = backup_processor.process_backups(omit_models=omit_models)
         logging.info("backup results = '%s'", backup_results)
@@ -157,11 +154,6 @@ class JujuBackupAllHelper:
         ssh_helper = SSHKeyHelper(self.config, self.accounts)
         ssh_helper.push_ssh_keys_to_models()
         return "success"
-
-    def update_global_vars(self):
-        """Update global variables used by the Juju-backup-all library."""
-        if self.charm_config["timeout"]:
-            globals.async_timeout = self.charm_config["timeout"]
 
     def update_crontab(self):
         """Update crontab "/etc/cron.d/juju-backup-all" that runs "auto_backup.py"."""


### PR DESCRIPTION
The PR fixes the bug where the charm would not propagate the timeout config to the `juju-backup-all` library if a backup is directly run by the charm, not through the cronjob.

The `auto_backup.py` script that is run by the cronjob [correctly updates](https://github.com/canonical/charm-juju-backup-all/blob/275604ac62e660d1c4dccd3e54547174cc3a94ad/scripts/templates/auto_backup.py#L235) the `globals.async_timeout` variable during each execution. 

However, when a backup is performed directly by the charm action, the global variable is not updated before the execution, which is a bug.

The `juju-backup-all` snap updates the aforementioned global variable on each invocation - [reference](https://github.com/canonical/juju-backup-all/blob/7adb0071a57562b45f4a37856c46dd7ac22b2fca/jujubackupall/cli.py#L84). But that part is missed in the charm, because it uses the snap as a library, rather than a snap

### EDIT 
We refactored the `juju-backup-all` to remove the global variable - https://github.com/canonical/juju-backup-all/pull/76. This PR removes the reference to the global variable

Closes: #62